### PR TITLE
Dynamic question prompt

### DIFF
--- a/whaaaaat/prompts/checkbox.py
+++ b/whaaaaat/prompts/checkbox.py
@@ -86,10 +86,10 @@ class InquirerControl(TokenListControl):
                         tokens.append((T.Selected, '\u25cf ', select_item))
                     else:
                         tokens.append((T, '\u25cb ', select_item))
-    
+
                     if pointed_at:
                         tokens.append((Token.SetCursorPosition, ''))
-    
+
                     tokens.append((T, line_name, select_item))
                 tokens.append((T, '\n'))
 
@@ -127,11 +127,12 @@ def question(message, **kwargs):
     style = kwargs.pop('style', default_style)
 
     ic = InquirerControl(choices)
+    qmark = kwargs.pop('qmark', '?')
 
     def get_prompt_tokens(cli):
         tokens = []
 
-        tokens.append((Token.QuestionMark, '?'))
+        tokens.append((Token.QuestionMark, qmark))
         tokens.append((Token.Question, ' %s ' % message))
         if ic.answered:
             nbr_selected = len(ic.selected_options)

--- a/whaaaaat/prompts/confirm.py
+++ b/whaaaaat/prompts/confirm.py
@@ -33,7 +33,7 @@ def question(message, **kwargs):
     def get_prompt_tokens(cli):
         tokens = []
 
-        tokens.append((Token.QuestionMark, '?'))
+        tokens.append((Token.QuestionMark, kwargs.pop('qmark', '?')))
         tokens.append((Token.Question, ' %s ' % message))
         if isinstance(status['answer'], bool):
             tokens.append((Token.Answer, ' Yes' if status['answer'] else ' No'))

--- a/whaaaaat/prompts/expand.py
+++ b/whaaaaat/prompts/expand.py
@@ -120,6 +120,7 @@ def question(message, **kwargs):
 
     choices = kwargs.pop('choices', None)
     default = kwargs.pop('default', None)
+    qmark = kwargs.pop('qmark', '?')
 
     # TODO style defaults on detail level
     style = kwargs.pop('style', default_style)
@@ -130,7 +131,7 @@ def question(message, **kwargs):
         tokens = []
         T = Token
 
-        tokens.append((T.QuestionMark, '?'))
+        tokens.append((T.QuestionMark, qmark))
         tokens.append((T.Question, ' %s ' % message))
         if not ic.answered:
             tokens.append((T.Instruction, ' (%s)' % ''.join(

--- a/whaaaaat/prompts/input.py
+++ b/whaaaaat/prompts/input.py
@@ -33,10 +33,11 @@ def question(message, **kwargs):
 
     # TODO style defaults on detail level
     kwargs['style'] = kwargs.pop('style', default_style)
+    qmark = kwargs.pop('qmark', '?')
 
     def _get_prompt_tokens(cli):
         return [
-            (Token.QuestionMark, '?'),
+            (Token.QuestionMark, qmark),
             (Token.Question, ' %s  ' % message)
         ]
 

--- a/whaaaaat/prompts/list.py
+++ b/whaaaaat/prompts/list.py
@@ -110,6 +110,7 @@ def question(message, **kwargs):
 
     choices = kwargs.pop('choices', None)
     default = kwargs.pop('default', 0)  # TODO
+    qmark = kwargs.pop('qmark', '?')
 
     # TODO style defaults on detail level
     style = kwargs.pop('style', default_style)
@@ -118,8 +119,7 @@ def question(message, **kwargs):
 
     def get_prompt_tokens(cli):
         tokens = []
-
-        tokens.append((Token.QuestionMark, '?'))
+        tokens.append((Token.QuestionMark, qmark))
         tokens.append((Token.Question, ' %s ' % message))
         if ic.answered:
             tokens.append((Token.Answer, ' ' + ic.get_selection()[0]))

--- a/whaaaaat/prompts/rawlist.py
+++ b/whaaaaat/prompts/rawlist.py
@@ -105,6 +105,8 @@ def question(message, **kwargs):
     #                     'use \'checked\':True\' in choice!')
 
     choices = kwargs.pop('choices', None)
+    qmark = kwargs.pop('qmark', '?')
+
     if len(choices) > 9:
         raise ValueError('rawlist supports only a maximum of 9 choices!')
 
@@ -117,7 +119,7 @@ def question(message, **kwargs):
         tokens = []
         T = Token
 
-        tokens.append((T.QuestionMark, '?'))
+        tokens.append((T.QuestionMark, qmark))
         tokens.append((T.Question, ' %s ' % message))
         if ic.answered:
             tokens.append((T.Answer, ' %s' % ic.get_selected_value()))


### PR DESCRIPTION
This PR introduces a dynamic question prompt functionality configurable by the `qmark` kwarg. When defining a questionnaire, simply add a `qmark` key/value pair to customize your prompt like so:
```python
questions = [
    {
       # ....
       'qmark': u'🐳 ',
       'message': 'Hey there, moby dick!'
    },
    {
        #...
        'message': 'Give me the key!',
        'qmark': u'🔑 ',
    }
]
``` 

Instead of question mark, you will see your customized prompt:
```shell
🐳 Hey there, moby dick!
🔑 Give me the key!
``` 