### PR TITLE
Custom final message on keyboard interrupt

### DIFF
--- a/whaaaaat/prompt.py
+++ b/whaaaaat/prompt.py
@@ -18,6 +18,7 @@ def prompt(questions, answers=None, **kwargs):
     true_color = kwargs.pop('true_color', False)
     refresh_interval = kwargs.pop('refresh_interval', 0)
     eventloop = kwargs.pop('eventloop', None)
+    kbi_msg = kwargs.pop('keyboard_interrupt_msg', 'Cancelled by user')
 
     for question in questions:
         # import the question
@@ -82,7 +83,7 @@ def prompt(questions, answers=None, **kwargs):
             raise ValueError('No question type \'%s\'' % type)
         except KeyboardInterrupt:
             print('')
-            print('Cancelled by user')
+            print(kbi_msg)
             print('')
             return {}
     return answers


### PR DESCRIPTION
This PR introduces an additional `kwarg` named `keyboard_interrupt_msg`, which let's you customize the output of `whaaaaat` when a user hits ctrl+c. Now hardcodede as `Cancelled by user`, this let's you do something like this:

```python
prompt(questions, style=style, keyboard_interrupt_msg="Ok ok, I'm backing off! See ya later")
```
which would result in:
```shell
[?] Some question where you hit ctrl+c

Ok ok, I'm backing off! See ya later
```