### PR TITLE
fix(requirements): pin prompt_toolkit version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-prompt_toolkit>=1.0.14
+prompt_toolkit==1.0.14
 Pygments>=2.2.0
 regex>=2016.11.21
 


### PR DESCRIPTION
Pinned prompt_toolkit to version 1.0.14. Previously, it would install ver 2.0, which has breaking changes.

fixes GH-23